### PR TITLE
Modular enemy behavior

### DIFF
--- a/decree/Lev1AFB.tmp
+++ b/decree/Lev1AFB.tmp
@@ -1,0 +1,123 @@
+[gd_scene load_steps=8 format=4 uid="uid://cc7nwj1biibuw"]
+
+[ext_resource type="Texture2D" uid="uid://di6y38yu85dr2" path="res://4_Seasons_Ground_Tiles.png" id="1_ruedu"]
+[ext_resource type="Script" path="res://level.gd" id="2_2idh2"]
+[ext_resource type="PackedScene" uid="uid://umydvt437mmv" path="res://Player.tscn" id="2_cq4we"]
+[ext_resource type="PackedScene" uid="uid://c4drp01fqj2e7" path="res://Enemy.tscn" id="3_3ige2"]
+[ext_resource type="PackedScene" uid="uid://ba12pskq3mu7k" path="res://Tile.tscn" id="5_mdl2r"]
+
+[sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_ojr4x"]
+texture = ExtResource("1_ruedu")
+0:0/0 = 0
+1:0/0 = 0
+2:0/0 = 0
+3:0/0 = 0
+4:0/0 = 0
+5:0/0 = 0
+6:0/0 = 0
+0:1/0 = 0
+1:1/0 = 0
+2:1/0 = 0
+3:1/0 = 0
+4:1/0 = 0
+5:1/0 = 0
+6:1/0 = 0
+0:2/0 = 0
+1:2/0 = 0
+2:2/0 = 0
+3:2/0 = 0
+4:2/0 = 0
+5:2/0 = 0
+6:2/0 = 0
+0:3/0 = 0
+1:3/0 = 0
+2:3/0 = 0
+3:3/0 = 0
+4:3/0 = 0
+5:3/0 = 0
+6:3/0 = 0
+0:4/0 = 0
+1:4/0 = 0
+2:4/0 = 0
+3:4/0 = 0
+4:4/0 = 0
+5:4/0 = 0
+6:4/0 = 0
+0:5/0 = 0
+1:5/0 = 0
+2:5/0 = 0
+3:5/0 = 0
+4:5/0 = 0
+5:5/0 = 0
+6:5/0 = 0
+0:6/0 = 0
+1:6/0 = 0
+2:6/0 = 0
+3:6/0 = 0
+4:6/0 = 0
+5:6/0 = 0
+6:6/0 = 0
+0:7/0 = 0
+1:7/0 = 0
+2:7/0 = 0
+3:7/0 = 0
+4:7/0 = 0
+5:7/0 = 0
+6:7/0 = 0
+0:8/0 = 0
+1:8/0 = 0
+2:8/0 = 0
+3:8/0 = 0
+4:8/0 = 0
+5:8/0 = 0
+6:8/0 = 0
+0:9/0 = 0
+1:9/0 = 0
+2:9/0 = 0
+3:9/0 = 0
+4:9/0 = 0
+5:9/0 = 0
+6:9/0 = 0
+0:10/0 = 0
+1:10/0 = 0
+2:10/0 = 0
+3:10/0 = 0
+4:10/0 = 0
+5:10/0 = 0
+6:10/0 = 0
+0:11/0 = 0
+1:11/0 = 0
+2:11/0 = 0
+3:11/0 = 0
+4:11/0 = 0
+5:11/0 = 0
+6:11/0 = 0
+
+[sub_resource type="TileSet" id="TileSet_uuxwi"]
+sources/0 = SubResource("TileSetAtlasSource_ojr4x")
+
+[node name="Level" type="Node2D"]
+script = ExtResource("2_2idh2")
+
+[node name="Terrain" type="TileMapLayer" parent="."]
+tile_map_data = PackedByteArray("AAAAAAAAAAADAAAAAAAAAAEAAAADAAAAAAAAAAIAAAADAAAAAAAAAAMAAAADAAAAAAABAAMAAAADAAAAAAADAAMAAAADAAAAAAACAAMAAAADAAAAAAADAAIAAAADAAAAAAACAAIAAAADAAAAAAABAAIAAAADAAAAAAADAAAAAAADAAAAAAADAAEAAAADAAAAAAACAAEAAAADAAAAAAACAAAAAAADAAAAAAABAAAAAAADAAAAAAABAAEAAAADAAAAAAA=")
+tile_set = SubResource("TileSet_uuxwi")
+
+[node name="Navigation" type="TileMapLayer" parent="."]
+
+[node name="Player" parent="Navigation" instance=ExtResource("2_cq4we")]
+visible = false
+position = Vector2(16, 32)
+
+[node name="Enemy" parent="Navigation" instance=ExtResource("3_3ige2")]
+visible = false
+
+[node name="Tile" parent="Navigation" instance=ExtResource("5_mdl2r")]
+visible = false
+
+[connection signal="confirm_attack" from="." to="Navigation/Player" method="_on_level_confirm_attack"]
+[connection signal="confirm_move" from="." to="Navigation/Player" method="_on_level_confirm_move"]
+[connection signal="attack" from="Navigation/Player" to="." method="_on_attack"]
+[connection signal="move" from="Navigation/Player" to="." method="_on_move"]
+[connection signal="click" from="Navigation/Tile" to="." method="_on_tile_click"]
+[connection signal="right_click" from="Navigation/Tile" to="." method="_on_tile_right_click"]

--- a/decree/Lev4CBC.tmp
+++ b/decree/Lev4CBC.tmp
@@ -1,0 +1,123 @@
+[gd_scene load_steps=8 format=4 uid="uid://cc7nwj1biibuw"]
+
+[ext_resource type="Texture2D" uid="uid://di6y38yu85dr2" path="res://4_Seasons_Ground_Tiles.png" id="1_ruedu"]
+[ext_resource type="Script" path="res://level.gd" id="2_2idh2"]
+[ext_resource type="PackedScene" uid="uid://umydvt437mmv" path="res://Player.tscn" id="2_cq4we"]
+[ext_resource type="PackedScene" uid="uid://c4drp01fqj2e7" path="res://Enemy.tscn" id="3_3ige2"]
+[ext_resource type="PackedScene" uid="uid://ba12pskq3mu7k" path="res://Tile.tscn" id="5_mdl2r"]
+
+[sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_ojr4x"]
+texture = ExtResource("1_ruedu")
+0:0/0 = 0
+1:0/0 = 0
+2:0/0 = 0
+3:0/0 = 0
+4:0/0 = 0
+5:0/0 = 0
+6:0/0 = 0
+0:1/0 = 0
+1:1/0 = 0
+2:1/0 = 0
+3:1/0 = 0
+4:1/0 = 0
+5:1/0 = 0
+6:1/0 = 0
+0:2/0 = 0
+1:2/0 = 0
+2:2/0 = 0
+3:2/0 = 0
+4:2/0 = 0
+5:2/0 = 0
+6:2/0 = 0
+0:3/0 = 0
+1:3/0 = 0
+2:3/0 = 0
+3:3/0 = 0
+4:3/0 = 0
+5:3/0 = 0
+6:3/0 = 0
+0:4/0 = 0
+1:4/0 = 0
+2:4/0 = 0
+3:4/0 = 0
+4:4/0 = 0
+5:4/0 = 0
+6:4/0 = 0
+0:5/0 = 0
+1:5/0 = 0
+2:5/0 = 0
+3:5/0 = 0
+4:5/0 = 0
+5:5/0 = 0
+6:5/0 = 0
+0:6/0 = 0
+1:6/0 = 0
+2:6/0 = 0
+3:6/0 = 0
+4:6/0 = 0
+5:6/0 = 0
+6:6/0 = 0
+0:7/0 = 0
+1:7/0 = 0
+2:7/0 = 0
+3:7/0 = 0
+4:7/0 = 0
+5:7/0 = 0
+6:7/0 = 0
+0:8/0 = 0
+1:8/0 = 0
+2:8/0 = 0
+3:8/0 = 0
+4:8/0 = 0
+5:8/0 = 0
+6:8/0 = 0
+0:9/0 = 0
+1:9/0 = 0
+2:9/0 = 0
+3:9/0 = 0
+4:9/0 = 0
+5:9/0 = 0
+6:9/0 = 0
+0:10/0 = 0
+1:10/0 = 0
+2:10/0 = 0
+3:10/0 = 0
+4:10/0 = 0
+5:10/0 = 0
+6:10/0 = 0
+0:11/0 = 0
+1:11/0 = 0
+2:11/0 = 0
+3:11/0 = 0
+4:11/0 = 0
+5:11/0 = 0
+6:11/0 = 0
+
+[sub_resource type="TileSet" id="TileSet_uuxwi"]
+sources/0 = SubResource("TileSetAtlasSource_ojr4x")
+
+[node name="Level" type="Node2D"]
+script = ExtResource("2_2idh2")
+
+[node name="Terrain" type="TileMapLayer" parent="."]
+tile_map_data = PackedByteArray("AAAAAAAAAAADAAAAAAAAAAEAAAADAAAAAAAAAAIAAAADAAAAAAAAAAMAAAADAAAAAAABAAMAAAADAAAAAAADAAMAAAADAAAAAAACAAMAAAADAAAAAAADAAIAAAADAAAAAAACAAIAAAADAAAAAAABAAIAAAADAAAAAAADAAAAAAADAAAAAAADAAEAAAADAAAAAAACAAEAAAADAAAAAAACAAAAAAADAAAAAAABAAAAAAADAAAAAAABAAEAAAADAAAAAAA=")
+tile_set = SubResource("TileSet_uuxwi")
+
+[node name="Navigation" type="TileMapLayer" parent="."]
+
+[node name="Player" parent="Navigation" instance=ExtResource("2_cq4we")]
+visible = false
+position = Vector2(16, 32)
+
+[node name="Enemy" parent="Navigation" instance=ExtResource("3_3ige2")]
+visible = false
+
+[node name="Tile" parent="Navigation" instance=ExtResource("5_mdl2r")]
+visible = false
+
+[connection signal="confirm_attack" from="." to="Navigation/Player" method="_on_level_confirm_attack"]
+[connection signal="confirm_move" from="." to="Navigation/Player" method="_on_level_confirm_move"]
+[connection signal="attack" from="Navigation/Player" to="." method="_on_attack"]
+[connection signal="move" from="Navigation/Player" to="." method="_on_move"]
+[connection signal="click" from="Navigation/Tile" to="." method="_on_tile_click"]
+[connection signal="right_click" from="Navigation/Tile" to="." method="_on_tile_right_click"]

--- a/decree/Lev62E4.tmp
+++ b/decree/Lev62E4.tmp
@@ -1,0 +1,123 @@
+[gd_scene load_steps=8 format=4 uid="uid://cc7nwj1biibuw"]
+
+[ext_resource type="Texture2D" uid="uid://di6y38yu85dr2" path="res://4_Seasons_Ground_Tiles.png" id="1_ruedu"]
+[ext_resource type="Script" path="res://level.gd" id="2_2idh2"]
+[ext_resource type="PackedScene" uid="uid://umydvt437mmv" path="res://Player.tscn" id="2_cq4we"]
+[ext_resource type="PackedScene" uid="uid://c4drp01fqj2e7" path="res://Enemy.tscn" id="3_3ige2"]
+[ext_resource type="PackedScene" uid="uid://ba12pskq3mu7k" path="res://Tile.tscn" id="5_mdl2r"]
+
+[sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_ojr4x"]
+texture = ExtResource("1_ruedu")
+0:0/0 = 0
+1:0/0 = 0
+2:0/0 = 0
+3:0/0 = 0
+4:0/0 = 0
+5:0/0 = 0
+6:0/0 = 0
+0:1/0 = 0
+1:1/0 = 0
+2:1/0 = 0
+3:1/0 = 0
+4:1/0 = 0
+5:1/0 = 0
+6:1/0 = 0
+0:2/0 = 0
+1:2/0 = 0
+2:2/0 = 0
+3:2/0 = 0
+4:2/0 = 0
+5:2/0 = 0
+6:2/0 = 0
+0:3/0 = 0
+1:3/0 = 0
+2:3/0 = 0
+3:3/0 = 0
+4:3/0 = 0
+5:3/0 = 0
+6:3/0 = 0
+0:4/0 = 0
+1:4/0 = 0
+2:4/0 = 0
+3:4/0 = 0
+4:4/0 = 0
+5:4/0 = 0
+6:4/0 = 0
+0:5/0 = 0
+1:5/0 = 0
+2:5/0 = 0
+3:5/0 = 0
+4:5/0 = 0
+5:5/0 = 0
+6:5/0 = 0
+0:6/0 = 0
+1:6/0 = 0
+2:6/0 = 0
+3:6/0 = 0
+4:6/0 = 0
+5:6/0 = 0
+6:6/0 = 0
+0:7/0 = 0
+1:7/0 = 0
+2:7/0 = 0
+3:7/0 = 0
+4:7/0 = 0
+5:7/0 = 0
+6:7/0 = 0
+0:8/0 = 0
+1:8/0 = 0
+2:8/0 = 0
+3:8/0 = 0
+4:8/0 = 0
+5:8/0 = 0
+6:8/0 = 0
+0:9/0 = 0
+1:9/0 = 0
+2:9/0 = 0
+3:9/0 = 0
+4:9/0 = 0
+5:9/0 = 0
+6:9/0 = 0
+0:10/0 = 0
+1:10/0 = 0
+2:10/0 = 0
+3:10/0 = 0
+4:10/0 = 0
+5:10/0 = 0
+6:10/0 = 0
+0:11/0 = 0
+1:11/0 = 0
+2:11/0 = 0
+3:11/0 = 0
+4:11/0 = 0
+5:11/0 = 0
+6:11/0 = 0
+
+[sub_resource type="TileSet" id="TileSet_uuxwi"]
+sources/0 = SubResource("TileSetAtlasSource_ojr4x")
+
+[node name="Level" type="Node2D"]
+script = ExtResource("2_2idh2")
+
+[node name="Terrain" type="TileMapLayer" parent="."]
+tile_map_data = PackedByteArray("AAAAAAAAAAADAAAAAAAAAAEAAAADAAAAAAAAAAIAAAADAAAAAAAAAAMAAAADAAAAAAABAAMAAAADAAAAAAADAAMAAAADAAAAAAACAAMAAAADAAAAAAADAAIAAAADAAAAAAACAAIAAAADAAAAAAABAAIAAAADAAAAAAADAAAAAAADAAAAAAADAAEAAAADAAAAAAACAAEAAAADAAAAAAACAAAAAAADAAAAAAABAAAAAAADAAAAAAABAAEAAAADAAAAAAA=")
+tile_set = SubResource("TileSet_uuxwi")
+
+[node name="Navigation" type="TileMapLayer" parent="."]
+
+[node name="Player" parent="Navigation" instance=ExtResource("2_cq4we")]
+visible = false
+position = Vector2(16, 32)
+
+[node name="Enemy" parent="Navigation" instance=ExtResource("3_3ige2")]
+visible = false
+
+[node name="Tile" parent="Navigation" instance=ExtResource("5_mdl2r")]
+visible = false
+
+[connection signal="confirm_attack" from="." to="Navigation/Player" method="_on_level_confirm_attack"]
+[connection signal="confirm_move" from="." to="Navigation/Player" method="_on_level_confirm_move"]
+[connection signal="attack" from="Navigation/Player" to="." method="_on_attack"]
+[connection signal="move" from="Navigation/Player" to="." method="_on_move"]
+[connection signal="click" from="Navigation/Tile" to="." method="_on_tile_click"]
+[connection signal="right_click" from="Navigation/Tile" to="." method="_on_tile_right_click"]

--- a/decree/Tile.tscn
+++ b/decree/Tile.tscn
@@ -5,6 +5,7 @@
 [ext_resource type="Texture2D" uid="uid://1ed74tdp6vy5" path="res://Tile Selector 7.png" id="2_oyt2u"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_bkiho"]
+resource_local_to_scene = true
 atlas = ExtResource("2_6ss7s")
 region = Rect2(48, 0, 16, 16)
 
@@ -16,7 +17,6 @@ script = ExtResource("1_vd0qm")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 position = Vector2(8, 8)
-scale = Vector2(1, 1)
 texture = SubResource("AtlasTexture_bkiho")
 
 [node name="TileSelector7" type="Sprite2D" parent="."]

--- a/decree/enemy.gd
+++ b/decree/enemy.gd
@@ -5,6 +5,8 @@ var hp : int
 var damage : int
 var has_moved : bool
 var board
+var speed : int
+var range : int
 
 func _ready():
 	var hp_display = str(hp)

--- a/decree/level.gd
+++ b/decree/level.gd
@@ -73,7 +73,7 @@ func _ready():
 		enemy.hp = 3
 		enemy.damage = 1
 		enemy.range = 1
-		enemy.speed = 2
+		enemy.speed = 1
 		enemy.board = board
 		enemy.board_position = Vector2i(-1,-1)
 		enemies.append(enemy)
@@ -120,7 +120,7 @@ func take_enemy_turns():
 			continue
 		#grid.set_point_solid(Vector2i(2,2))
 		#grid.set_point_solid(Vector2i(2,2))
-		var dest = move_patterns.shift_targeted(enemy, player.board_position)
+		var dest = move_patterns.shift_chase(enemy, player.board_position)
 		if len(dest) > 0:
 			for j in range(len(dest)):
 				var move_success = move(enemy, dest[j], tween)
@@ -183,17 +183,20 @@ func _on_tile_click(tile):
 	if active_entity != player or player.board_position == tile.board_position:
 		return
 	var tween = create_tween()
-	if !active_entity.has_moved and board[tile.board_position[0]][tile.board_position[1]] == null and !grid.is_point_solid(Vector2i(tile.board_position[0], tile.board_position[1])):
-		move(active_entity, tile.board_position, tween)
-		highlight_targets(active_entity.board_position)
+	if !player.has_moved and board[tile.board_position[0]][tile.board_position[1]] == null and !grid.is_point_solid(Vector2i(tile.board_position[0], tile.board_position[1])):
+		if is_in_range(player.board_position, tile.board_position, player.speed):
+			var dest = move_patterns.shift_target(player, tile.board_position)
+			if dest != null:
+				move(player, tile.board_position, tween)
+				highlight_targets(player.board_position)
 	else:
-		attack(active_entity, tile.board_position)
+		attack(player, tile.board_position)
 
 func _on_tile_right_click():
 	if active_entity != player:
 		return
 	var tween = create_tween()
-	if active_entity.has_moved:
+	if player.has_moved:
 		revert_move(tween)
 
 func highlight_targets(board_position):

--- a/decree/move_patterns.gd
+++ b/decree/move_patterns.gd
@@ -7,7 +7,7 @@ func get_board_position(position : Vector2):
 	var snapped_position = (int_position - (int_position % Vector2i(16,16))) / 16
 	return snapped_position
 
-func shift_targeted(entity, target):
+func shift_chase(entity, target):
 	if grid.is_dirty():
 		grid.update()
 	var dest = []
@@ -17,7 +17,16 @@ func shift_targeted(entity, target):
 			dest.append(path[i])
 	dest.reverse()
 	return dest
-#
+
+func shift_target(entity, target):
+	if grid.is_dirty():
+		grid.update()
+	var path = grid.get_id_path(entity.board_position, target, false)
+	if len(path) > entity.speed + 1:
+		return null
+	else:
+		return target
+
 #func shift_two_targeted(entity, target):
 	#if grid.is_dirty():
 		#grid.update()

--- a/decree/move_patterns.gd
+++ b/decree/move_patterns.gd
@@ -1,0 +1,28 @@
+class_name MovePatterns
+
+var grid : AStarGrid2D
+
+func get_board_position(position : Vector2):
+	var int_position = Vector2i(floori(position[0]), floori(position[1]))
+	var snapped_position = (int_position - (int_position % Vector2i(16,16))) / 16
+	return snapped_position
+
+func shift_one_targeted(entity, target):
+	if grid.is_dirty():
+		grid.update()
+	var path = grid.get_id_path(entity.board_position, target, true)
+	if len(path) > 2:
+		return path[1]
+	else: 
+		return null
+
+func shift_two_targeted(entity, target):
+	if grid.is_dirty():
+		grid.update()
+	var path = grid.get_id_path(entity.board_position, target, true)
+	if len(path) > 3:
+		return path[2]
+	elif len(path) > 2:
+		return path[1] 
+	else: 
+		return null

--- a/decree/move_patterns.gd
+++ b/decree/move_patterns.gd
@@ -7,23 +7,24 @@ func get_board_position(position : Vector2):
 	var snapped_position = (int_position - (int_position % Vector2i(16,16))) / 16
 	return snapped_position
 
-func shift_one_targeted(entity, target):
-	#grid.set_point_solid(Vector2i(2,2))
+func shift_targeted(entity, target):
 	if grid.is_dirty():
 		grid.update()
+	var dest = []
 	var path = grid.get_id_path(entity.board_position, target, true)
 	if len(path) > 2:
-		return path[1]
-	else: 
-		return null
-
-func shift_two_targeted(entity, target):
-	if grid.is_dirty():
-		grid.update()
-	var path = grid.get_id_path(entity.board_position, target, true)
-	if len(path) > 3:
-		return path[2]
-	elif len(path) > 2:
-		return path[1] 
-	else: 
-		return null
+		for i in range(1, entity.speed + 1):
+			dest.append(path[i])
+	dest.reverse()
+	return dest
+#
+#func shift_two_targeted(entity, target):
+	#if grid.is_dirty():
+		#grid.update()
+	#var path = grid.get_id_path(entity.board_position, target, true)
+	#var dest = []
+	#if len(path) > 2:
+		#for i in range(1,3):
+			#dest.append(path[i])
+	#dest.reverse()
+	#return dest

--- a/decree/move_patterns.gd
+++ b/decree/move_patterns.gd
@@ -8,6 +8,7 @@ func get_board_position(position : Vector2):
 	return snapped_position
 
 func shift_one_targeted(entity, target):
+	#grid.set_point_solid(Vector2i(2,2))
 	if grid.is_dirty():
 		grid.update()
 	var path = grid.get_id_path(entity.board_position, target, true)

--- a/decree/player.gd
+++ b/decree/player.gd
@@ -6,6 +6,7 @@ var hp : int
 var damage : int
 var has_moved : bool
 var range : int
+var speed : int
 
 signal move(entity, target)
 signal attack(entity, target)

--- a/decree/rock.tscn
+++ b/decree/rock.tscn
@@ -1,0 +1,13 @@
+[gd_scene load_steps=3 format=3 uid="uid://bl8kl8d2h8vdm"]
+
+[ext_resource type="Texture2D" uid="uid://di6y38yu85dr2" path="res://4_Seasons_Ground_Tiles.png" id="1_i34vh"]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_4cocn"]
+atlas = ExtResource("1_i34vh")
+region = Rect2(96, 32, 16, 16)
+
+[node name="Node2D" type="Node2D"]
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+position = Vector2(8, 8)
+texture = SubResource("AtlasTexture_4cocn")


### PR DESCRIPTION
Refactor to easy repository of movement patterns that enemies and player both use. Player and enemies both have a personal speed stat now, which effects how the movement patterns work.

Two movement patterns so far are:
shift_chase: move up to your speed in the direction of the target (useful for enemies), blocked by other entities and obstacles
shift_target: move to target tile if the distance is your speed or less, blocked by non-entity obstacles (though you still cannot end your turn on another entity). Default behavior for player movement.
 